### PR TITLE
Force create only, update is optional

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,6 +7,8 @@ Progress and time estimation is displayed during the scrolling process.
 
 ## Requirements
 
+Ruby 1.8.6 or newer is required, use [rvm](https://rvm.io/) for convenience.
+
 Following gems are required via `Gemfile`:
 
 + [rest-client] (https://github.com/archiloque/rest-client)
@@ -31,11 +33,13 @@ Refer to script's help:
     
         - -r - remove the index in the new location first
         - -f - specify frame size to be obtained with one fetch during scrolling
+        - -u - update existing documents (default: only create non-existing)
         - optional source/destination urls default to http://127.0.0.1:9200
 
 
 ## Changelog
 
++ __0.0.4__: Force create only, update is optional (@pgaertig)
 + __0.0.3__: Yajl -> Oj
 + __0.0.2__: repated document count comparison
 + __0.0.1__: first revision


### PR DESCRIPTION
Here is the change which makes `es-reindexer` more convenient for live index migration. Create only default prevents overwriting documents which already exist in destination. E.g. these can be new documents just added to new index by clients where re-indexation of old data from old index is in progress. Destructive update mode can be enabled by `-u` parameter.
