### PR TITLE
remove any trailing slashes in the url that would break the regex

### DIFF
--- a/es-reindex.rb
+++ b/es-reindex.rb
@@ -35,7 +35,8 @@ while ARGV[0]
 	when '-f' then frame = ARGV.shift.to_i
         when '-u' then update = true
 	else
-		!src ? (src = arg) : !dst ? (dst = arg) :
+		url = arg.chomp("/")
+		!src ? (src = url) : !dst ? (dst = url) :
 			raise("Unexpected parameter '#{arg}'. Use '-h' for help.")
 	end
 end


### PR DESCRIPTION
If someone tries to use a url like "http://srcurl/indexname/" for the source or the destination, the code isn't able to parse out the index name. This is perhaps not the most elegant fix, but it does allow the use of these visibly valid urls.

Great script by the way! Extremely helpful!
