### PR TITLE
add option -i to ignore creating the destination index and only copy

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,6 +39,8 @@ Refer to script's help:
 
 ## Changelog
 
++ __0.0.8__: Add option -i to ignore creating the destination index and
+  only copy documents 
 + __0.0.7__: Document header arguments `_timestamp` and `_ttl` are copied as well
 + __0.0.6__: Document headers in bulks are now assembled and properly JSON dumped
 + __0.0.5__: Merge fix for trailing slash in urls (@ichinco), formatting cleanup


### PR DESCRIPTION
We needed the ability to copy documents into a new index with different mappings. I added the -i option to disable creating the destination index assuming that this index is already created. When -i is passed it will only copy the documents from the source/index. This was used for reindexing when we needed to change the mappings.
