### PR TITLE
search_type=scan replaced with sort=_doc as it was depricated in ES

### DIFF
--- a/es-reindex.rb
+++ b/es-reindex.rb
@@ -131,7 +131,7 @@ t, done = Time.now, 0
 shards = retried_request :get, "#{surl}/#{sidx}/_count?q=*"
 shards = Oj.load(shards)['_shards']['total'].to_i
 scan = retried_request(:get, "#{surl}/#{sidx}/_search" +
-    "?search_type=scan&scroll=10m&size=#{frame / shards}")
+    "?sort=_doc&scroll=10m&size=#{frame / shards}")
 scan = Oj.load scan
 scroll_id = scan['_scroll_id']
 total = scan['hits']['total']


### PR DESCRIPTION
search_type=scan replaced with sort=_doc as it was depricated in ES 2.1
and must be replaced with sort=_doc
(https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-request-search-type.html#scan)
