### PR TITLE
Es 5

### DIFF
--- a/es-reindex.rb
+++ b/es-reindex.rb
@@ -131,7 +131,7 @@ t, done = Time.now, 0
 shards = retried_request :get, "#{surl}/#{sidx}/_count?q=*"
 shards = Oj.load(shards)['_shards']['total'].to_i
 scan = retried_request(:get, "#{surl}/#{sidx}/_search" +
-    "?search_type=scan&scroll=10m&size=#{frame / shards}")
+    "?sort=_doc&scroll=10m&size=#{frame / shards}")
 scan = Oj.load scan
 scroll_id = scan['_scroll_id']
 total = scan['hits']['total']


### PR DESCRIPTION
Added support for ElasticSearch 5+

index/_search uses different requests for version 5+
  search_type=scan replaced with sort=_doc as it was depricated in ES
  2.1 and must be replaced with sort=_doc
  (https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-request-search-type.html#scan)

_search/scroll is uses different request for versions 5+

Tested with AWS ES 1.5, 2.3, 5.1.
